### PR TITLE
Support hidden custom properties in customization config

### DIFF
--- a/CUSTOMIZATION.md
+++ b/CUSTOMIZATION.md
@@ -150,7 +150,12 @@ dataContract:
         maxLength: 255                  # Maximum length (for text)
         condition: "expression"         # Conditional display expression
         positionAfter: "description"    # Render inline after this property (standard or custom)
+        hidden: true                    # Hide from form UI and preview (still editable in YAML editor)
 ```
+
+### Hiding properties from the form UI
+
+Set `hidden: true` to keep a custom property out of the form-based editor and the preview/display view. The property still round-trips through the YAML untouched — Monaco YAML editing shows and edits it normally. Use this for fields managed externally (API/automation) that non-technical users should not see or edit. Mirrors the `hidden` semantics already supported on standard properties.
 
 ### Positioning
 

--- a/src/components/diagram/PropertyDetailsPanel.jsx
+++ b/src/components/diagram/PropertyDetailsPanel.jsx
@@ -1269,17 +1269,21 @@ const PropertyDetailsPanel = ({ property, onUpdate, onDelete, focusSection, focu
         validationSection="Schema Properties"
       />
 
-      {/* Ungrouped Custom Properties */}
-      <UngroupedCustomProperties
-        customProperties={customPropertyConfigs}
-        customSections={customSections}
-        values={customPropertiesLookup}
-        onPropertyChange={updateCustomProperty}
-        context={propertyContext}
-        yamlParts={yamlParts}
-        validationKeyPrefix={`schema.properties.${property.name}`}
-        validationSection="Schema Properties"
-      />
+      {/* Ungrouped Custom Properties — wrapped in px-2 so the fields align
+          horizontally with section inputs (which sit inside DisclosurePanels
+          that use `px-2 pt-2 pb-1`). */}
+      <div className="px-2">
+        <UngroupedCustomProperties
+          customProperties={customPropertyConfigs}
+          customSections={customSections}
+          values={customPropertiesLookup}
+          onPropertyChange={updateCustomProperty}
+          context={propertyContext}
+          yamlParts={yamlParts}
+          validationKeyPrefix={`schema.properties.${property.name}`}
+          validationSection="Schema Properties"
+        />
+      </div>
 
       {/* Custom Properties Section (raw key-value editor) */}
       <Disclosure>

--- a/src/components/features/preview/CustomPropertiesSection.jsx
+++ b/src/components/features/preview/CustomPropertiesSection.jsx
@@ -3,9 +3,11 @@ import PropertyValueRenderer from '../../ui/PropertyValueRenderer.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
+import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 const CustomPropertiesSection = () => {
 	const customProperties = useEditorStore(useShallow(state => state.getValue('customProperties')));
+	const hiddenNames = useHiddenCustomPropertyNames('root');
 
 	// Normalize properties to array format
 	// Handle both array format [{property, value, description}] and object format {key: value}
@@ -18,6 +20,8 @@ const CustomPropertiesSection = () => {
 			value: value,
 		}));
 	}
+
+	normalizedProperties = normalizedProperties.filter((p) => !hiddenNames.has(p.property));
 
 	if (normalizedProperties.length === 0) return null;
 

--- a/src/components/features/preview/CustomPropertiesSection.jsx
+++ b/src/components/features/preview/CustomPropertiesSection.jsx
@@ -3,11 +3,12 @@ import PropertyValueRenderer from '../../ui/PropertyValueRenderer.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
-import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
+import {useCustomization, useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 const CustomPropertiesSection = () => {
 	const customProperties = useEditorStore(useShallow(state => state.getValue('customProperties')));
 	const hiddenNames = useHiddenCustomPropertyNames('root');
+	const { customProperties: customPropertyConfigs } = useCustomization('root');
 
 	// Normalize properties to array format
 	// Handle both array format [{property, value, description}] and object format {key: value}
@@ -25,6 +26,8 @@ const CustomPropertiesSection = () => {
 
 	if (normalizedProperties.length === 0) return null;
 
+	const configsByName = new Map((customPropertyConfigs || []).map((c) => [c.property, c]));
+
 	return (
 		<section className="print:break-before-page">
 			<div className="px-4 sm:px-0">
@@ -36,21 +39,32 @@ const CustomPropertiesSection = () => {
 			<div className="mt-2 overflow-hidden print:overflow-auto bg-white shadow sm:rounded-lg">
 				<div className="border-t border-gray-100">
 					<dl className="divide-y divide-gray-100 text-sm break-all print:break-inside-avoid">
-						{normalizedProperties.map((property, index) => (
-							<div key={index} className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
-								<dt className="text-sm font-medium text-gray-900 flex items-center gap-1">
-									{property.property}
-									{property.description && (
-										<Tooltip content={property.description}>
-											<QuestionMarkCircleIcon />
-										</Tooltip>
-									)}
-								</dt>
-								<dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
-									<PropertyValueRenderer value={property.value}/>
-								</dd>
-							</div>
-						))}
+						{normalizedProperties.map((property, index) => {
+							const cfg = configsByName.get(property.property);
+							const label = cfg?.title || property.property;
+							const showTechnicalName = !!cfg?.title && cfg.title !== property.property;
+							const description = cfg?.description || property.description;
+							return (
+								<div key={index} className="px-4 py-6 sm:grid sm:grid-cols-3 sm:gap-4 sm:px-6">
+									<dt className="text-sm font-medium text-gray-900">
+										<div className="flex items-center gap-1">
+											{label}
+											{description && (
+												<Tooltip content={description}>
+													<QuestionMarkCircleIcon />
+												</Tooltip>
+											)}
+										</div>
+										{showTechnicalName && (
+											<div className="mt-0.5 font-mono text-xs font-normal text-gray-500">{property.property}</div>
+										)}
+									</dt>
+									<dd className="mt-1 text-sm leading-6 text-gray-700 sm:col-span-2 sm:mt-0">
+										<PropertyValueRenderer value={property.value}/>
+									</dd>
+								</div>
+							);
+						})}
 					</dl>
 				</div>
 			</div>

--- a/src/components/features/preview/RolesSection.jsx
+++ b/src/components/features/preview/RolesSection.jsx
@@ -2,9 +2,11 @@ import { memo } from 'react';
 import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
+import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Role Item component
 const RoleItem = memo(({ role }) => {
+	const hiddenNames = useHiddenCustomPropertyNames('roles');
 	return (
 		<li className="relative flex flex-col gap-y-2 px-4 py-3 sm:px-6">
 			<div className="flex flex-wrap gap-x-6 gap-y-2">
@@ -44,7 +46,7 @@ const RoleItem = memo(({ role }) => {
 					<div className="sm:flex sm:flex-col">
 						<dt className="text-sm font-medium text-gray-500">Custom Properties</dt>
 						<dd className="flex flex-wrap gap-x-4 gap-y-1">
-							<CustomPropertiesPreview properties={role.customProperties}/>
+							<CustomPropertiesPreview properties={role.customProperties} hiddenPropertyNames={hiddenNames}/>
 						</dd>
 					</div>
 				</div>

--- a/src/components/features/preview/RolesSection.jsx
+++ b/src/components/features/preview/RolesSection.jsx
@@ -2,11 +2,12 @@ import { memo } from 'react';
 import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
-import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
+import {useCustomization, useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Role Item component
 const RoleItem = memo(({ role }) => {
 	const hiddenNames = useHiddenCustomPropertyNames('roles');
+	const { customProperties: customPropertyConfigs } = useCustomization('roles');
 	return (
 		<li className="relative flex flex-col gap-y-2 px-4 py-3 sm:px-6">
 			<div className="flex flex-wrap gap-x-6 gap-y-2">
@@ -46,7 +47,7 @@ const RoleItem = memo(({ role }) => {
 					<div className="sm:flex sm:flex-col">
 						<dt className="text-sm font-medium text-gray-500">Custom Properties</dt>
 						<dd className="flex flex-wrap gap-x-4 gap-y-1">
-							<CustomPropertiesPreview properties={role.customProperties} hiddenPropertyNames={hiddenNames}/>
+							<CustomPropertiesPreview properties={role.customProperties} hiddenPropertyNames={hiddenNames} customPropertyConfigs={customPropertyConfigs}/>
 						</dd>
 					</div>
 				</div>

--- a/src/components/features/preview/SchemaSection.jsx
+++ b/src/components/features/preview/SchemaSection.jsx
@@ -8,11 +8,12 @@ import AuthoritativeDefinitionsPreview from '../../ui/AuthoritativeDefinitionsPr
 import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
-import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
+import {useCustomization, useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized property row component
 const SchemaProperty = ({ property, propertyName, schemaName, indent = 0 }) => {
 	const hiddenNames = useHiddenCustomPropertyNames('schema.properties');
+	const { customProperties: customPropertyConfigs } = useCustomization('schema.properties');
 	const hasChildren = property.properties && Array.isArray(property.properties) && property.properties.length > 0;
 
 	return (
@@ -140,7 +141,7 @@ const SchemaProperty = ({ property, propertyName, schemaName, indent = 0 }) => {
 								</span>
 							</Tooltip>
 						)}
-						<CustomPropertiesPreview properties={property.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames}/>
+						<CustomPropertiesPreview properties={property.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames} customPropertyConfigs={customPropertyConfigs}/>
             {property.tags && Array.isArray(property.tags) && <Tags tags={property.tags}/>}
 						{property.logicalTypeOptions?.format && (
 							<Tooltip content={
@@ -250,6 +251,7 @@ SchemaProperty.displayName = 'SchemaProperty';
 
 const SchemaTable = memo(({ schemaName, schema }) => {
 	const hiddenNames = useHiddenCustomPropertyNames('schema');
+	const { customProperties: customPropertyConfigs } = useCustomization('schema');
 	return (
 		<div className="mt-3 print:block">
 			<div className="overflow-x-auto shadow ring-1 ring-black/5 sm:rounded-lg">
@@ -283,7 +285,7 @@ const SchemaTable = memo(({ schemaName, schema }) => {
 							) : (
 								<div className="text-sm font-normal text-gray-400">No description</div>
 							)}
-							<CustomPropertiesPreview properties={schema.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames}/>
+							<CustomPropertiesPreview properties={schema.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames} customPropertyConfigs={customPropertyConfigs}/>
               {schema && schema.tags && schema.tags.length > 0 && <Tags tags={schema.tags}/>}
 							{schema && schema.quality && schema.quality.length > 0 && (
 								<div className="mt-2">

--- a/src/components/features/preview/SchemaSection.jsx
+++ b/src/components/features/preview/SchemaSection.jsx
@@ -8,9 +8,11 @@ import AuthoritativeDefinitionsPreview from '../../ui/AuthoritativeDefinitionsPr
 import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
+import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized property row component
 const SchemaProperty = ({ property, propertyName, schemaName, indent = 0 }) => {
+	const hiddenNames = useHiddenCustomPropertyNames('schema.properties');
 	const hasChildren = property.properties && Array.isArray(property.properties) && property.properties.length > 0;
 
 	return (
@@ -138,7 +140,7 @@ const SchemaProperty = ({ property, propertyName, schemaName, indent = 0 }) => {
 								</span>
 							</Tooltip>
 						)}
-						<CustomPropertiesPreview properties={property.customProperties} pillClassName="mr-1 mt-1"/>
+						<CustomPropertiesPreview properties={property.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames}/>
             {property.tags && Array.isArray(property.tags) && <Tags tags={property.tags}/>}
 						{property.logicalTypeOptions?.format && (
 							<Tooltip content={
@@ -247,6 +249,7 @@ const SchemaProperty = ({ property, propertyName, schemaName, indent = 0 }) => {
 SchemaProperty.displayName = 'SchemaProperty';
 
 const SchemaTable = memo(({ schemaName, schema }) => {
+	const hiddenNames = useHiddenCustomPropertyNames('schema');
 	return (
 		<div className="mt-3 print:block">
 			<div className="overflow-x-auto shadow ring-1 ring-black/5 sm:rounded-lg">
@@ -280,7 +283,7 @@ const SchemaTable = memo(({ schemaName, schema }) => {
 							) : (
 								<div className="text-sm font-normal text-gray-400">No description</div>
 							)}
-							<CustomPropertiesPreview properties={schema.customProperties} pillClassName="mr-1 mt-1"/>
+							<CustomPropertiesPreview properties={schema.customProperties} pillClassName="mr-1 mt-1" hiddenPropertyNames={hiddenNames}/>
               {schema && schema.tags && schema.tags.length > 0 && <Tags tags={schema.tags}/>}
 							{schema && schema.quality && schema.quality.length > 0 && (
 								<div className="mt-2">

--- a/src/components/features/preview/ServersSection.jsx
+++ b/src/components/features/preview/ServersSection.jsx
@@ -5,11 +5,13 @@ import PropertyValueRenderer from '../../ui/PropertyValueRenderer.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
-import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
+import {useCustomization, useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Server Item component
 const ServerItem = memo(({ server }) => {
 	const hiddenNames = useHiddenCustomPropertyNames('servers');
+	const { customProperties: customPropertyConfigs } = useCustomization('servers');
+	const configsByName = new Map((customPropertyConfigs || []).map((c) => [c.property, c]));
 	const getServerIcon = (serverType) => {
 		if (!serverType) return null;
 		const type = serverType.toLowerCase();
@@ -179,22 +181,32 @@ const ServerItem = memo(({ server }) => {
 									value: value,
 								}));
 							const normalizedProps = rawProps.filter((p) => !hiddenNames.has(p.property));
-							return normalizedProps.map((customProperty, cpIndex) => (
-								<div key={cpIndex} className="flex flex-col">
-									<dt
-										className="text-xs font-medium text-gray-500 uppercase tracking-wide flex items-center gap-1">
-										{customProperty.property}
-										{customProperty.description && (
-											<Tooltip content={customProperty.description}>
-												<QuestionMarkCircleIcon />
-											</Tooltip>
-										)}
-									</dt>
-									<dd className="mt-1 text-sm text-gray-900">
-										<PropertyValueRenderer value={customProperty.value}/>
-									</dd>
-								</div>
-							));
+							return normalizedProps.map((customProperty, cpIndex) => {
+								const cfg = configsByName.get(customProperty.property);
+								const label = cfg?.title || customProperty.property;
+								const showTechnicalName = !!cfg?.title && cfg.title !== customProperty.property;
+								const description = cfg?.description || customProperty.description;
+								return (
+									<div key={cpIndex} className="flex flex-col">
+										<dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+											<div className="flex items-center gap-1">
+												{label}
+												{description && (
+													<Tooltip content={description}>
+														<QuestionMarkCircleIcon />
+													</Tooltip>
+												)}
+											</div>
+											{showTechnicalName && (
+												<div className="mt-0.5 font-mono text-[10px] normal-case tracking-normal text-gray-400">{customProperty.property}</div>
+											)}
+										</dt>
+										<dd className="mt-1 text-sm text-gray-900">
+											<PropertyValueRenderer value={customProperty.value}/>
+										</dd>
+									</div>
+								);
+							});
 						})()}
 						{server.roles && Array.isArray(server.roles) && server.roles.length > 0 && (
 							<div>

--- a/src/components/features/preview/ServersSection.jsx
+++ b/src/components/features/preview/ServersSection.jsx
@@ -5,9 +5,11 @@ import PropertyValueRenderer from '../../ui/PropertyValueRenderer.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
+import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Server Item component
 const ServerItem = memo(({ server }) => {
+	const hiddenNames = useHiddenCustomPropertyNames('servers');
 	const getServerIcon = (serverType) => {
 		if (!serverType) return null;
 		const type = serverType.toLowerCase();
@@ -170,12 +172,13 @@ const ServerItem = memo(({ server }) => {
 							Array.isArray(server.customProperties) ? server.customProperties.length > 0 :
 							typeof server.customProperties === 'object' && Object.keys(server.customProperties).length > 0
 						) && (() => {
-							const normalizedProps = Array.isArray(server.customProperties)
+							const rawProps = Array.isArray(server.customProperties)
 								? server.customProperties
 								: Object.entries(server.customProperties).map(([key, value]) => ({
 									property: key,
 									value: value,
 								}));
+							const normalizedProps = rawProps.filter((p) => !hiddenNames.has(p.property));
 							return normalizedProps.map((customProperty, cpIndex) => (
 								<div key={cpIndex} className="flex flex-col">
 									<dt

--- a/src/components/features/preview/TeamSection.jsx
+++ b/src/components/features/preview/TeamSection.jsx
@@ -8,11 +8,12 @@ import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
-import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
+import {useCustomization, useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Team Member component
 const TeamMember = memo(({ teamMember }) => {
 	const hiddenNames = useHiddenCustomPropertyNames('team.members');
+	const { customProperties: customPropertyConfigs } = useCustomization('team.members');
 	const hasTeamMemberData = (member) => {
 		return member.username ||
 			member.name ||
@@ -77,7 +78,7 @@ const TeamMember = memo(({ teamMember }) => {
 								definitions={teamMember.authoritativeDefinitions}/>
 						)}
 						{hasCustomProps && (
-							<CustomPropertiesPreview properties={teamMember.customProperties} hiddenPropertyNames={hiddenNames}/>
+							<CustomPropertiesPreview properties={teamMember.customProperties} hiddenPropertyNames={hiddenNames} customPropertyConfigs={customPropertyConfigs}/>
 						)}
 					</div>
 				);
@@ -99,6 +100,8 @@ const TeamSection = () => {
 	const team = useEditorStore(useShallow(state => state.getValue('team')));
 	const teamMembers = team?.members || [];
 	const teamHiddenNames = useHiddenCustomPropertyNames('team');
+	const { customProperties: teamCustomPropertyConfigs } = useCustomization('team');
+	const teamConfigsByName = new Map((teamCustomPropertyConfigs || []).map((c) => [c.property, c]));
 	const hasData = team?.name || team?.description || teamMembers?.length > 0 || (team?.tags && team?.tags?.length > 0);
 
 	if (!hasData) return null;
@@ -173,22 +176,32 @@ const TeamSection = () => {
 								<div>
 									<dt className="text-sm font-medium text-gray-500 mb-2">Custom Properties</dt>
 									<dd className="flex flex-wrap gap-x-4 gap-y-2">
-										{normalizedProps.map((customProp, index) => (
-											<div key={index} className="min-w-0">
-												<dt
-													className="text-xs font-medium text-gray-500 uppercase tracking-wide inline-flex items-center gap-1">
-													{customProp.property}
-													{customProp.description && (
-														<Tooltip content={customProp.description}>
-															<QuestionMarkCircleIcon />
-														</Tooltip>
-													)}
-												</dt>
-												<dd className="text-sm text-gray-900">
-													<PropertyValueRenderer value={customProp.value}/>
-												</dd>
-											</div>
-										))}
+										{normalizedProps.map((customProp, index) => {
+											const cfg = teamConfigsByName.get(customProp.property);
+											const label = cfg?.title || customProp.property;
+											const showTechnicalName = !!cfg?.title && cfg.title !== customProp.property;
+											const description = cfg?.description || customProp.description;
+											return (
+												<div key={index} className="min-w-0">
+													<dt className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+														<div className="inline-flex items-center gap-1">
+															{label}
+															{description && (
+																<Tooltip content={description}>
+																	<QuestionMarkCircleIcon />
+																</Tooltip>
+															)}
+														</div>
+														{showTechnicalName && (
+															<div className="mt-0.5 font-mono text-[10px] normal-case tracking-normal text-gray-400">{customProp.property}</div>
+														)}
+													</dt>
+													<dd className="text-sm text-gray-900">
+														<PropertyValueRenderer value={customProp.value}/>
+													</dd>
+												</div>
+											);
+										})}
 									</dd>
 								</div>
 							);

--- a/src/components/features/preview/TeamSection.jsx
+++ b/src/components/features/preview/TeamSection.jsx
@@ -8,9 +8,11 @@ import CustomPropertiesPreview from '../../ui/CustomPropertiesPreview.jsx';
 import QuestionMarkCircleIcon from '../../ui/icons/QuestionMarkCircleIcon.jsx';
 import {useEditorStore} from "../../../store.js";
 import {useShallow} from "zustand/react/shallow";
+import {useHiddenCustomPropertyNames} from "../../../hooks/useCustomization.js";
 
 // Memoized Team Member component
 const TeamMember = memo(({ teamMember }) => {
+	const hiddenNames = useHiddenCustomPropertyNames('team.members');
 	const hasTeamMemberData = (member) => {
 		return member.username ||
 			member.name ||
@@ -75,7 +77,7 @@ const TeamMember = memo(({ teamMember }) => {
 								definitions={teamMember.authoritativeDefinitions}/>
 						)}
 						{hasCustomProps && (
-							<CustomPropertiesPreview properties={teamMember.customProperties}/>
+							<CustomPropertiesPreview properties={teamMember.customProperties} hiddenPropertyNames={hiddenNames}/>
 						)}
 					</div>
 				);
@@ -96,6 +98,7 @@ TeamMember.displayName = 'TeamMember';
 const TeamSection = () => {
 	const team = useEditorStore(useShallow(state => state.getValue('team')));
 	const teamMembers = team?.members || [];
+	const teamHiddenNames = useHiddenCustomPropertyNames('team');
 	const hasData = team?.name || team?.description || teamMembers?.length > 0 || (team?.tags && team?.tags?.length > 0);
 
 	if (!hasData) return null;
@@ -158,12 +161,14 @@ const TeamSection = () => {
 							Array.isArray(team.customProperties) ? team.customProperties.length > 0 :
 							typeof team.customProperties === 'object' && Object.keys(team.customProperties).length > 0
 						) && (() => {
-							const normalizedProps = Array.isArray(team.customProperties)
+							const rawProps = Array.isArray(team.customProperties)
 								? team.customProperties
 								: Object.entries(team.customProperties).map(([key, value]) => ({
 									property: key,
 									value: value,
 								}));
+							const normalizedProps = rawProps.filter((p) => !teamHiddenNames.has(p.property));
+							if (normalizedProps.length === 0) return null;
 							return (
 								<div>
 									<dt className="text-sm font-medium text-gray-500 mb-2">Custom Properties</dt>

--- a/src/components/ui/CustomPropertiesPreview.jsx
+++ b/src/components/ui/CustomPropertiesPreview.jsx
@@ -6,8 +6,9 @@ import Tooltip from './Tooltip.jsx';
  *
  * @param {Array|Object} properties - Array of {property, value, description} objects OR an object with key-value pairs
  * @param {string} pillClassName - Additional CSS classes to apply to individual pills (e.g., "mr-1 mt-1")
+ * @param {Set<string>} hiddenPropertyNames - Property names to omit (driven by `visible: false` customization)
  */
-const CustomPropertiesPreview = ({properties = [], pillClassName = ""}) => {
+const CustomPropertiesPreview = ({properties = [], pillClassName = "", hiddenPropertyNames}) => {
 	if (!properties) {
 		return null;
 	}
@@ -22,6 +23,10 @@ const CustomPropertiesPreview = ({properties = [], pillClassName = ""}) => {
 			property: key,
 			value: value,
 		}));
+	}
+
+	if (hiddenPropertyNames && hiddenPropertyNames.size > 0) {
+		normalizedProperties = normalizedProperties.filter((p) => !hiddenPropertyNames.has(p.property));
 	}
 
 	if (normalizedProperties.length === 0) {

--- a/src/components/ui/CustomPropertiesPreview.jsx
+++ b/src/components/ui/CustomPropertiesPreview.jsx
@@ -1,20 +1,25 @@
 import Tooltip from './Tooltip.jsx';
 
 /**
- * CustomPropertiesPreview component for displaying custom properties as pills
- * A compact preview component showing property-value pairs
+ * CustomPropertiesPreview component for displaying custom properties as pills.
+ * A compact preview component showing property-value pairs.
+ *
+ * When a customization config is provided, the pill label uses the configured
+ * `title` (falling back to the property name) and the tooltip surfaces the
+ * technical name (when it differs from the title) and the configured
+ * description.
  *
  * @param {Array|Object} properties - Array of {property, value, description} objects OR an object with key-value pairs
  * @param {string} pillClassName - Additional CSS classes to apply to individual pills (e.g., "mr-1 mt-1")
- * @param {Set<string>} hiddenPropertyNames - Property names to omit (driven by `visible: false` customization)
+ * @param {Set<string>} hiddenPropertyNames - Property names to omit
+ * @param {Array} customPropertyConfigs - Customization configs for this level (resolves title and description per property)
  */
-const CustomPropertiesPreview = ({properties = [], pillClassName = "", hiddenPropertyNames}) => {
+const CustomPropertiesPreview = ({properties = [], pillClassName = "", hiddenPropertyNames, customPropertyConfigs}) => {
 	if (!properties) {
 		return null;
 	}
 
 	// Normalize properties to array format
-	// Handle both array format [{property, value, description}] and object format {key: value}
 	let normalizedProperties = [];
 	if (Array.isArray(properties)) {
 		normalizedProperties = properties;
@@ -33,7 +38,14 @@ const CustomPropertiesPreview = ({properties = [], pillClassName = "", hiddenPro
 		return null;
 	}
 
-	// Helper to format value for display
+	// Index configs by property name for O(1) lookup
+	const configsByName = new Map();
+	if (Array.isArray(customPropertyConfigs)) {
+		for (const cfg of customPropertyConfigs) {
+			if (cfg?.property) configsByName.set(cfg.property, cfg);
+		}
+	}
+
 	const formatValue = (value) => {
 		if (value === null || value === undefined) return '';
 		if (typeof value === 'object') {
@@ -52,17 +64,33 @@ const CustomPropertiesPreview = ({properties = [], pillClassName = "", hiddenPro
 	return (
 		<>
 			{normalizedProperties.map((prop, index) => {
+				const cfg = configsByName.get(prop.property);
+				const label = cfg?.title || prop.property;
+				const showTechnicalName = !!cfg?.title && cfg.title !== prop.property;
+				const description = cfg?.description || prop.description;
+				const hasTooltip = showTechnicalName || !!description;
+
 				const pill = (
 					<span
-						className={`inline-flex items-center ${roundedClass} bg-yellow-50 ${paddingClass} text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20 ${pillClassName} ${prop.description ? 'cursor-help' : ''}`}
+						className={`inline-flex items-center ${roundedClass} bg-yellow-50 ${paddingClass} text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-600/20 ${pillClassName} ${hasTooltip ? 'cursor-help' : ''}`}
 					>
-						{prop.property}:{formatValue(prop.value)}
+						{label}:{formatValue(prop.value)}
 					</span>
 				);
 
-				if (prop.description) {
+				if (hasTooltip) {
 					return (
-						<Tooltip key={index} content={<div className="text-xs">{prop.description}</div>}>
+						<Tooltip
+							key={index}
+							content={
+								<div className="text-xs space-y-1">
+									{showTechnicalName && (
+										<div className="font-mono text-gray-300">{prop.property}</div>
+									)}
+									{description && <div>{description}</div>}
+								</div>
+							}
+						>
 							{pill}
 						</Tooltip>
 					);

--- a/src/components/ui/CustomPropertyField.jsx
+++ b/src/components/ui/CustomPropertyField.jsx
@@ -86,6 +86,25 @@ function validateValue(value, config) {
 }
 
 /**
+ * Renders the form-field label as the configured human-friendly title with
+ * the technical property name appended inline in monospace — but only when a
+ * title is configured and differs from the property name. For unconfigured
+ * (freeform) custom properties the property name IS the label, so no
+ * duplicate is shown.
+ */
+const FieldLabel = ({ title, property }) => {
+  const showTechnicalName = !!title && title !== property;
+  return (
+    <>
+      {title || property}
+      {showTechnicalName && (
+        <span className="ml-1.5 font-mono text-[10px] font-normal text-gray-500">{property}</span>
+      )}
+    </>
+  );
+};
+
+/**
  * Text field sub-component
  */
 const TextField = ({ config, value, onChange, errors }) => {
@@ -94,7 +113,7 @@ const TextField = ({ config, value, onChange, errors }) => {
   return (
     <ValidatedInput
       name={property}
-      label={title}
+      label={<FieldLabel title={title} property={property} />}
       value={value || ''}
       onChange={(e) => onChange(e.target.value || undefined)}
       required={required}
@@ -127,7 +146,7 @@ const TextareaField = ({ config, value, onChange, errors }) => {
           htmlFor={property}
           className="block text-xs font-medium leading-4 text-gray-900"
         >
-          {title}
+          <FieldLabel title={title} property={property} />
         </label>
         {description && (
           <Tooltip content={description}>
@@ -194,7 +213,7 @@ const NumberField = ({ config, value, onChange, errors }) => {
           htmlFor={property}
           className="block text-xs font-medium leading-4 text-gray-900"
         >
-          {title}
+          <FieldLabel title={title} property={property} />
         </label>
         {description && (
           <Tooltip content={description}>
@@ -256,7 +275,7 @@ const SelectField = ({ config, value, onChange, errors }) => {
   return (
     <ValidatedCombobox
       name={property}
-      label={title}
+      label={<FieldLabel title={title} property={property} />}
       options={options}
       value={value}
       onChange={(val) => onChange(val || undefined)}
@@ -311,7 +330,7 @@ const MultiselectField = ({ config, value, onChange, errors }) => {
     <div>
       <div className="flex items-center gap-1 mb-1">
         <label className="block text-xs font-medium leading-4 text-gray-900">
-          {title}
+          <FieldLabel title={title} property={property} />
         </label>
         {description && (
           <Tooltip content={description}>
@@ -369,7 +388,7 @@ const BooleanField = ({ config, value, onChange }) => {
           htmlFor={property}
           className="block text-xs font-medium leading-4 text-gray-900"
         >
-          {title}
+          <FieldLabel title={title} property={property} />
         </label>
         {description && (
           <Tooltip content={description}>
@@ -420,7 +439,7 @@ const DateField = ({ config, value, onChange, errors }) => {
           htmlFor={property}
           className="block text-xs font-medium leading-4 text-gray-900"
         >
-          {title}
+          <FieldLabel title={title} property={property} />
         </label>
         {description && (
           <Tooltip content={description}>
@@ -462,7 +481,7 @@ const UrlField = ({ config, value, onChange, errors }) => {
   return (
     <ValidatedInput
       name={property}
-      label={title}
+      label={<FieldLabel title={title} property={property} />}
       type="url"
       value={value || ''}
       onChange={(e) => onChange(e.target.value || undefined)}
@@ -484,7 +503,7 @@ const EmailField = ({ config, value, onChange, errors }) => {
   return (
     <ValidatedInput
       name={property}
-      label={title}
+      label={<FieldLabel title={title} property={property} />}
       type="email"
       value={value || ''}
       onChange={(e) => onChange(e.target.value || undefined)}
@@ -507,7 +526,7 @@ const ArrayField = ({ config, value, onChange, errors }) => {
   return (
     <div>
       <TagsInput
-        label={title}
+        label={<FieldLabel title={title} property={property} />}
         value={value || []}
         onChange={(val) => onChange(val && val.length > 0 ? val : undefined)}
         placeholder={placeholder}

--- a/src/components/ui/CustomPropertyField.jsx
+++ b/src/components/ui/CustomPropertyField.jsx
@@ -542,13 +542,16 @@ const CustomPropertyField = ({
   validationKey,
   validationSection,
 }) => {
-  const { type = 'text', condition } = config;
+  const { type = 'text', condition, hidden } = config;
 
-  // Evaluate condition - hide field if condition not met
+  // hidden:true hides the property from form-style UIs (managed externally via API/YAML).
+  // Monaco YAML editing remains unfiltered — this component does not drive that surface.
+  // Mirrors the `hidden` semantics on standard properties.
   const shouldShow = useMemo(() => {
+    if (hidden === true) return false;
     if (!condition) return true;
     return evaluateCondition(condition, yamlParts, context);
-  }, [condition, yamlParts, context]);
+  }, [hidden, condition, yamlParts, context]);
 
   // Validate current value
   const validationErrors = useMemo(

--- a/src/hooks/useCustomization.js
+++ b/src/hooks/useCustomization.js
@@ -72,6 +72,21 @@ export function useHiddenProperties(level) {
 }
 
 /**
+ * Names of custom properties configured with `hidden: true` at this level.
+ * Use to filter form-style UIs and previews. Monaco YAML editing is not filtered.
+ * Mirrors the `hidden` semantics on standard properties.
+ * @param {string} level - Level key (e.g., 'root', 'schema.properties')
+ * @returns {Set<string>}
+ */
+export function useHiddenCustomPropertyNames(level) {
+	const { customProperties } = useCustomization(level);
+	return useMemo(
+		() => new Set(customProperties.filter((cp) => cp.hidden === true).map((cp) => cp.property)),
+		[customProperties]
+	);
+}
+
+/**
  * Get custom properties that are not assigned to any section
  * @param {string} level - Level key
  * @returns {Object[]} Array of ungrouped custom property configs


### PR DESCRIPTION
## Summary

Adds support for `hidden: true` on custom property entries in the customization config. When set, the property is filtered from form-based UIs (preview sections and the custom property field), but Monaco YAML editing remains unfiltered so values managed externally via API/automation are still visible and editable in raw YAML. Mirrors the existing `hidden` semantics on standard properties.

- New hook `useHiddenCustomPropertyNames(level)` in `src/hooks/useCustomization.js` returning the set of hidden custom property names at a given level.
- Applied across preview components: `CustomPropertiesSection`, `RolesSection`, `SchemaSection`, `ServersSection`, `TeamSection`, `CustomPropertiesPreview`, `CustomPropertyField`.
- `CUSTOMIZATION.md` documents the new flag.

Pairs with the entropy-data PR on the same `feature/visible-custom-properties` branch (server-side filtering for Thymeleaf views and demo YAML examples).