### PR TITLE
fix(SchemaEditor): inherit logicalType and description from the definition

### DIFF
--- a/src/components/features/SchemaEditor.jsx
+++ b/src/components/features/SchemaEditor.jsx
@@ -448,8 +448,10 @@ const SchemaEditor = ({schemaIndex}) => {
 		setSelectedPropertyPath(null);
 	}, []);
 
-	// Add property from a selected definition
-	// Only sets name and definition link - other values are inherited from the definition
+	// Add property from a selected definition.
+	// Inherits the concept's logicalType and description when provided, so the
+	// property is complete enough for downstream tooling (e.g. a contract test
+	// emits a type check only when the property carries a type).
 	const addPropertyFromDefinition = useCallback((definition) => {
 		try {
 			if (!schema || !schema[schemaIndex]) {
@@ -461,6 +463,8 @@ const SchemaEditor = ({schemaIndex}) => {
 			const currentProperties = schema[schemaIndex].properties || [];
 			const newProperty = {
 				name: definition.businessName || definition.name?.split('/').pop() || '',
+				...(definition.logicalType ? { logicalType: definition.logicalType } : {}),
+				...(definition.description ? { description: definition.description } : {}),
 				authoritativeDefinitions: [{type: 'semantics', url: definition.url}],
 			};
 


### PR DESCRIPTION
## Summary

`addPropertyFromDefinition` built the new property with only `name` and `authoritativeDefinitions`, even though its own comment said *"other values are inherited from the definition"*. The `definition` object already provides `logicalType` and `description` (via `nodeToDefinition`), so a property added from a semantic definition was created without a type.

A property with neither `logicalType` nor `physicalType` is under-specified: ODCS contract tooling skips the type check entirely for it. This change copies `logicalType` and `description` through when the definition provides them, so the property is complete by default (no behavior change when the definition lacks them).
