### PR TITLE
CLI mode: hide the file menu and show the edited file path in the header

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -135,7 +135,10 @@ init({
   showPreview: true,
 
   // Mode
-  mode: 'SERVER',                    // 'SERVER', 'DESKTOP', or 'EMBEDDED'
+  mode: 'SERVER',                    // 'SERVER', 'DESKTOP', 'CLI', or 'EMBEDDED'
+                                     // CLI: bound to a single local file (datacontract edit),
+                                     // Save button only, no New/Load Example/Open menu
+  filePath: null,                    // Path of the edited file, shown in the header (CLI mode)
 
   // Callbacks (EMBEDDED mode)
   onSave: (yaml, { markers, yamlParseError }) => {},  // return false to prevent clearing dirty state

--- a/src/embed.jsx
+++ b/src/embed.jsx
@@ -62,11 +62,15 @@ const DEFAULT_CONFIG = {
     helpText: null, // Custom help text (HTML string) - replaces default CLI instructions
   },
 
-  // Editor mode: 'SERVER' (default), 'DESKTOP', or 'EMBEDDED'
+  // Editor mode: 'SERVER' (default), 'DESKTOP', 'CLI', or 'EMBEDDED'
   // - SERVER: Server mode with full menu
   // - DESKTOP: Desktop mode with file operations in menu
+  // - CLI: CLI mode (datacontract edit) editing a single local file: Save button only, no menu
   // - EMBEDDED: Embedded mode with Cancel/Delete/Save buttons, no menu
   mode: 'SERVER',
+
+  // Path of the file being edited, shown in the header (used by CLI mode)
+  filePath: null,
 
   // Callbacks
   onSave: null,        // (yaml, { markers, yamlParseError }) => void | false
@@ -358,6 +362,7 @@ function createConfiguredStore(config) {
 			// Store editor config for components to access
 			editorConfig: {
 				mode: config.mode,
+				filePath: config.filePath,
 				onCancel: config.onCancel,
 				onDelete: config.onDelete,
 				showDelete: config.showDelete,

--- a/src/layouts/Header.jsx
+++ b/src/layouts/Header.jsx
@@ -36,13 +36,15 @@ const Header = () => {
 	const yamlParseError = useEditorStore((state) => state.yamlParseError);
 	const contractName = useEditorStore((state) => state.getValue('name'));
 
-	// Check if we're in server mode
-	const backend = getFileStorageBackend();
-	const isServerMode = backend.getBackendName() === 'Server Storage';
-
 	// Get editor mode from config
 	const editorMode = editorConfig?.mode || 'SERVER';
 	const isEmbeddedMode = editorMode === 'EMBEDDED';
+
+	// Check if we're in server mode. CLI mode (datacontract edit) behaves the same:
+	// the editor is bound to a single managed file, so New / Load Example / Open
+	// make no sense and the menu is hidden.
+	const backend = getFileStorageBackend();
+	const isServerMode = backend.getBackendName() === 'Server Storage' || editorMode === 'CLI';
 	const [showParseErrorModal, setShowParseErrorModal] = useState(false);
 	// Calculate problem count
 	const totalCount = markers.length;
@@ -441,11 +443,18 @@ const Header = () => {
 									</linearGradient>
 								</defs>
 							</svg>
-							<span className="text-md leading-tight text-gray-900">
-												{editorConfig.titlePrefix
-													? `${editorConfig.titlePrefix} ${contractName}`
-													: 'Data Contract Editor'}
-                    </span>
+							<div className="flex flex-col min-w-0">
+								<span className="text-md leading-tight text-gray-900">
+													{editorConfig.titlePrefix
+														? `${editorConfig.titlePrefix} ${contractName}`
+														: 'Data Contract Editor'}
+									</span>
+								{editorConfig.filePath && (
+									<span className="text-xs leading-tight text-gray-500 truncate" title={editorConfig.filePath}>
+										{editorConfig.filePath}
+									</span>
+								)}
+							</div>
 						</div>
 						{/* View tabs - centered, responsive */}
 						<div className="flex flex-row flex-1 justify-center items-center">


### PR DESCRIPTION
In CLI mode (`datacontract edit`), the editor is bound to a single local file, so New / Load Example / Open make no sense and the menu is now hidden, same as in server mode. The new `filePath` config option shows the path of the edited file under the title in the header.

Companion change in datacontract-cli passes `filePath` from `datacontract edit`.

Verified end-to-end with a local build served through the CLI edit server: header shows the file path under the title, and only the Save button remains on the right.